### PR TITLE
Refactored removing duplicate from header list

### DIFF
--- a/verify-dkim.py
+++ b/verify-dkim.py
@@ -77,12 +77,12 @@ def hash_headers(mail: email.message.Message, header_to_hash: str, bh: str) -> S
     #
 
     header_to_hash_list = header_to_hash.split(":")
+    header_to_hash_list = list(dict.fromkeys(header_to_hash_list)) # Remove duplicate header i.e. from
     headers = ""
 
     for header in header_to_hash_list:
         if mail[header] and header in header_to_hash_list:
             headers += header.lower() + ":" + mail[header].strip() + "\r\n"
-            header_to_hash_list.remove(header) # strip duplicate header like the from
 
     dkim_header = mail.get("DKIM-Signature")
     dkim_header = re.sub(r'(\n|\r)', "", dkim_header)


### PR DESCRIPTION
Currently, if header_to_hash_list doesn't contain any duplicate items then it won't get all the items when it goes through the loop. Hence, in the end, headers would not have all the tags. This would fix the issue. 

```python
header_to_hash_list = ['mime-version', 'from', 'date', 'message-id', 'subject', 'to']

content_in_header_to_hash_list_after_for_loop = ['from', 'message-id', 'to']
```